### PR TITLE
Migration to cvelib native cve_api interface in stead of command line

### DIFF
--- a/program/cve_publish_update.py
+++ b/program/cve_publish_update.py
@@ -6,19 +6,31 @@ import json
 import time
 import sys
 from dateutil.parser import parse
+from cvelib.cve_api import CveApi
 
 # Helper functions
+
+def cve_exec(bla):
+    print(bla)
+    raise "bla"
 
 def exec(cmd):
     stream = os.popen(cmd)
     return(stream.read())
 
-def cve_exec(arguments):
-    stream = os.popen("cve {} --raw".format(arguments))
-    json_data = json.loads(stream.read())
-    stream.close()
-    return json_data
 
+def cve_api_login() -> CveApi:
+    cve_api = CveApi(
+        username=os.getenv("CVE_USER"),
+        org=os.getenv("CVE_ORG"),
+        api_key=os.getenv("CVE_API_KEY"),
+        env=os.getenv("CVE_ENVIRONMENT")
+    )
+    return cve_api
+
+# Global
+
+cve_api = None
 
 # Main
 
@@ -35,18 +47,19 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     # Is CVE lib installed
-    cvelib_path=exec("which cve")
-    if cvelib_path == "":
-        print("No output for `which cve`, cvelib is no installed", file=sys.stderr)
-        exit(255)
-    org = exec("cve org")
-    if "ERROR" in org :
+    #cvelib_path=exec("which cve")
+    #if cvelib_path == "":
+    #    print("No output for `which cve`, cvelib is no installed", file=sys.stderr)
+    #    exit(255)
+    cve_api = cve_api_login()
+    try:
+        org = cve_api.show_org()
+    except:
         print("Unable to list organisation via cvelib, have you set your authentication variables?", file=sys.stderr)
         exit(255)
-    org = cve_exec("org")
-    cves = cve_exec("list")
 
     updated=0
+    created=0
     for root, dirs, files in os.walk(args.path):
         for file in files:
             if file.endswith(".json"):
@@ -77,7 +90,7 @@ if __name__ == '__main__':
 
                 # Do you own the record?
                 if file_valid:
-                    cve_metadata=cve_exec("show {}".format(cve_id))
+                    cve_metadata = cve_api.show_cve_id(cve_id)
                     if cve_metadata["owning_cna"] != org["short_name"] :
                         print("{} is not owned by {}, but by {}, skipping file.".format(cve_id, org["short_name"],cve_metadata["owning_cna"]),file=sys.stderr)
                         file_valid=False
@@ -88,17 +101,33 @@ if __name__ == '__main__':
                     file_valid=False
 
                 # Doers the record ened to be published or updated?
-                if file_valid and json_data["cveMetadata"]["state"] == "PUBLISHED":
+                if file_valid and cve_metadata["state"] == "RESERVED" and json_data["cveMetadata"]["state"] == "PUBLISHED":
+                    # Need to publish this CVE
+                    try:
+                        result = cve_api.publish(cve_id,json_data["containers"]["cna"])
+                    except Exception as e:
+                        print(e)
+                    else:
+                        print(result["message"])
+                        created=createded+1
+
+
+                if file_valid and cve_metadata["state"] == "PUBLISHED" and json_data["cveMetadata"]["state"] == "PUBLISHED":
+                    # We need to update the record if the local record is newer then the server record
                     file_date_str=exec("git log -1 --pretty='format:%ci' {}".format(filename))
                     file_date = parse(file_date_str)
                     server_date = parse(cve_metadata["time"]["modified"])
                     if ( file_date > server_date or cve_metadata["state"] == "RESERVED" ) :
-                        result = cve_exec("publish -j '{}' {}".format(json.dumps(json_data["containers"]["cna"], separators=(',', ':')), cve_id))
-                        print(result["message"])
-                        updated=updated+1
+                        try:
+                            result = cve_api.update_published(cve_id,json_data["containers"]["cna"])
+                        except Exception as e:
+                            print(e)
+                        else:
+                            print(result["message"])
+                            updated=updated+1
                     else:
                         print("Record for {} is up to date".format(cve_id))
 
                 if file_valid and json_data["cveMetadata"]["state"] != "RESERVED" and json_data["cveMetadata"]["state"] != "PUBLISHED" :
-                    print("State of {} is not 'RESERVED' or 'PUBLISHED', don;t know what to do with a '{}' record. Skipping.".format(cve_id,json_data["cveMetadata"]["state"]))
-    print("\n{} record(s) published/updated.".format(updated))
+                    print("State of {} is not 'RESERVED' or 'PUBLISHED', don't know what to do with a '{}' record. Skipping.".format(cve_id,json_data["cveMetadata"]["state"]))
+    print("\n{} record(s) created, {} record(s) updated.".format(created,updated))

--- a/test-cves/2022/CVE-2022-36248.json
+++ b/test-cves/2022/CVE-2022-36248.json
@@ -1,0 +1,238 @@
+    {
+        "containers": {
+            "cna": {
+                "affected": [
+                    {
+                        "product": "Qlik Sense Enterprise on Windows",
+                        "vendor": "Qlik Sense",
+                        "versions": [
+                            {
+                                "lessThan": "14.44.0",
+                                "status": "affected",
+                                "version": "14.x",
+                                "versionType": "custom"
+                            }
+                        ]
+                    }
+                ],
+                "credits": [
+                    {
+                        "lang": "en",
+                        "value": "This issue was discovered by Hidde Smit of DIVD. "
+                    }
+                ],
+                "datePublic": "2022-02-21T00:00:00",
+                "descriptions": [
+                    {
+                        "lang": "en",
+                        "value": "A vulnerability in Qlik Sense Enterprise on Windows could allow an remote attacker to enumerate domain user accounts. An attacker could exploit this vulnerability by sending authentication requests to an affected system. A successful exploit could allow the attacker to compare the response time that are returned by the affected system to determine which accounts are valid user accounts. Affected systems are only vulnerable if they have LDAP configured."
+                    }
+                ],
+                "metrics": [
+                    {
+                        "cvssV3_1": {
+                            "attackComplexity": "LOW",
+                            "attackVector": "NETWORK",
+                            "availabilityImpact": "NONE",
+                            "baseScore": 5.3,
+                            "baseSeverity": "MEDIUM",
+                            "confidentialityImpact": "LOW",
+                            "integrityImpact": "NONE",
+                            "privilegesRequired": "NONE",
+                            "scope": "UNCHANGED",
+                            "userInteraction": "NONE",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                            "version": "3.1"
+                        }
+                    }
+                ],
+                "problemTypes": [
+                    {
+                        "descriptions": [
+                            {
+                                "cweId": "CWE-204",
+                                "description": "CWE-204: Observable Response Discrepancy",
+                                "lang": "en",
+                                "type": "CWE"
+                            }
+                        ]
+                    }
+                ],
+                "providerMetadata": {
+                    "dateUpdated": "2022-03-02T00:00:00",
+                    "orgId": "69632286-1972-4f77-9f90-cf5d0d963fb7",
+                    "shortName": "DIVD"
+                },
+                "references": [
+                    {
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_CONFIRM"
+                        ],
+                        "url": "https://csirt.divd.nl/cases/DIVD-2021-00021"
+                    },
+                    {
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_CONFIRM"
+                        ],
+                        "url": "https://csirt.divd.nl/cves/CVE-2022-0564"
+                    },
+                    {
+                        "tags": [
+                            "vendor-advisory",
+                            "x_refsource_CONFIRM"
+                        ],
+                        "url": "https://community.qlik.com/t5/Release-Notes/Qlik-Sense-Enterprise-on-Windows-November-2021-Initial-Release/ta-p/1856531"
+                    }
+                ],
+                "solutions": [
+                    {
+                        "lang": "en",
+                        "value": "Update Qlik Sense Enterprise on Windows to version 14.44.0 or higher."
+                    }
+                ],
+                "source": {
+                    "advisory": "DIVD-2021-00021",
+                    "discovery": "INTERNAL"
+                },
+                "title": "Qlik Sense Enterprise Domain User enumeration",
+                "workarounds": [
+                    {
+                        "lang": "en",
+                        "value": "Disable internet-facing NTLM endpoints, e.g. internal_windows_authentication, to avoid domain enumeration."
+                    }
+                ],
+                "x_generator": {
+                    "engine": "Vulnogram 0.0.9"
+                },
+                "x_legacyV4Record": {
+                    "CVE_data_meta": {
+                        "ASSIGNER": "csirt@divd.nl",
+                        "DATE_PUBLIC": "2022-02-21T14:30:00.000Z",
+                        "ID": "CVE-2022-0564",
+                        "STATE": "PUBLIC",
+                        "TITLE": "Qlik Sense Enterprise Domain User enumeration"
+                    },
+                    "affects": {
+                        "vendor": {
+                            "vendor_data": [
+                                {
+                                    "product": {
+                                        "product_data": [
+                                            {
+                                                "product_name": "Qlik Sense Enterprise on Windows",
+                                                "version": {
+                                                    "version_data": [
+                                                        {
+                                                            "version_affected": "<",
+                                                            "version_name": "14.x",
+                                                            "version_value": "14.44.0"
+                                                        }
+                                                    ]
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    "vendor_name": "Qlik Sense"
+                                }
+                            ]
+                        }
+                    },
+                    "credit": [
+                        {
+                            "lang": "eng",
+                            "value": "This issue was discovered by Hidde Smit of DIVD. "
+                        }
+                    ],
+                    "data_format": "MITRE",
+                    "data_type": "CVE",
+                    "data_version": "4.0",
+                    "description": {
+                        "description_data": [
+                            {
+                                "lang": "eng",
+                                "value": "A vulnerability in Qlik Sense Enterprise on Windows could allow an remote attacker to enumerate domain user accounts. An attacker could exploit this vulnerability by sending authentication requests to an affected system. A successful exploit could allow the attacker to compare the response time that are returned by the affected system to determine which accounts are valid user accounts. Affected systems are only vulnerable if they have LDAP configured."
+                            }
+                        ]
+                    },
+                    "generator": {
+                        "engine": "Vulnogram 0.0.9"
+                    },
+                    "impact": {
+                        "cvss": {
+                            "attackComplexity": "LOW",
+                            "attackVector": "NETWORK",
+                            "availabilityImpact": "NONE",
+                            "baseScore": 5.3,
+                            "baseSeverity": "MEDIUM",
+                            "confidentialityImpact": "LOW",
+                            "integrityImpact": "NONE",
+                            "privilegesRequired": "NONE",
+                            "scope": "UNCHANGED",
+                            "userInteraction": "NONE",
+                            "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N",
+                            "version": "3.1"
+                        }
+                    },
+                    "problemtype": {
+                        "problemtype_data": [
+                            {
+                                "description": [
+                                    {
+                                        "lang": "eng",
+                                        "value": "CWE-204: Observable Response Discrepancy"
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    "references": {
+                        "reference_data": [
+                            {
+                                "name": "https://csirt.divd.nl/cases/DIVD-2021-00021",
+                                "refsource": "CONFIRM",
+                                "url": "https://csirt.divd.nl/cases/DIVD-2021-00021"
+                            },
+                            {
+                                "name": "https://csirt.divd.nl/cves/CVE-2022-0564",
+                                "refsource": "CONFIRM",
+                                "url": "https://csirt.divd.nl/cves/CVE-2022-0564"
+                            },
+                            {
+                                "name": "https://community.qlik.com/t5/Release-Notes/Qlik-Sense-Enterprise-on-Windows-November-2021-Initial-Release/ta-p/1856531",
+                                "refsource": "CONFIRM",
+                                "url": "https://community.qlik.com/t5/Release-Notes/Qlik-Sense-Enterprise-on-Windows-November-2021-Initial-Release/ta-p/1856531"
+                            }
+                        ]
+                    },
+                    "solution": [
+                        {
+                            "lang": "en",
+                            "value": "Update Qlik Sense Enterprise on Windows to version 14.44.0 or higher."
+                        }
+                    ],
+                    "source": {
+                        "advisory": "DIVD-2021-00021",
+                        "discovery": "INTERNAL"
+                    },
+                    "work_around": [
+                        {
+                            "lang": "en",
+                            "value": "Disable internet-facing NTLM endpoints, e.g. internal_windows_authentication, to avoid domain enumeration."
+                        }
+                    ]
+                }
+            }
+        },
+        "cveMetadata": {
+            "assignerOrgId": "69632286-1972-4f77-9f90-cf5d0d963fb7",
+            "assignerShortName": "DIVD",
+            "cveId": "CVE-2022-36248",
+            "datePublished": "2022-02-21T00:00:00",
+            "dateUpdated": "2022-03-02T00:00:00",
+            "state": "PUBLISHED"
+        },
+        "dataType": "CVE_RECORD",
+        "dataVersion": "5.0"
+    }


### PR DESCRIPTION
Also:
* enabled publisher_match check for real
* fixes #8 - Bug: CVE records that have ' in their body cannot be submitted